### PR TITLE
workarounds for dhclient and cassandra

### DIFF
--- a/tcp_tests/templates/salt/mk22-qa-lab01-salt.yaml
+++ b/tcp_tests/templates/salt/mk22-qa-lab01-salt.yaml
@@ -124,6 +124,19 @@
   retry: {count: 3, delay: 10}
   skip_fail: false
 
+- description: Workaround for VMs: set low 'max_heap_size' for Cassandra
+  cmd: |
+    cat << 'EOF' >> /srv/salt/reclass/classes/system/linux/system/single.yml
+    # opencontrail lowmem
+      opencontrail:
+        database:
+          max_heap_size: "1G"
+          heap_newsize: "200M"
+    EOF
+  node_name: cfg01.mk22-qa-lab01.local
+  retry: {count: 1, delay: 1}
+  skip_fail: false
+
 
 # Prepare salt services and nodes settings
 - description: Run 'linux' formula on cfg01

--- a/tcp_tests/templates/salt/mk22-qa-lab01-salt.yaml
+++ b/tcp_tests/templates/salt/mk22-qa-lab01-salt.yaml
@@ -124,6 +124,19 @@
   retry: {count: 3, delay: 10}
   skip_fail: false
 
+- description: * Workaround for VMs: set low 'max_heap_size' for Cassandra
+  cmd: |
+    cat << 'EOF' >> /srv/salt/reclass/classes/system/linux/system/single.yml
+    # opencontrail lowmem
+      opencontrail:
+        database:
+          max_heap_size: "1G"
+          heap_newsize: "200M"
+    EOF
+  node_name: cfg01.mk22-qa-lab01.local
+  retry: {count: 1, delay: 1}
+  skip_fail: false
+
 
 # Prepare salt services and nodes settings
 - description: Run 'linux' formula on cfg01

--- a/tcp_tests/templates/underlay/mk22-lab-advanced--user-data-cfg01.yaml
+++ b/tcp_tests/templates/underlay/mk22-lab-advanced--user-data-cfg01.yaml
@@ -48,7 +48,7 @@
    ########################################################
 
   write_files:
-   - path: /etc/network/interfaces.d/99-tcp-tests.cfg
+   - path: /etc/network/interfaces
      content: |
           auto ens3
           iface ens3 inet dhcp

--- a/tcp_tests/templates/underlay/mk22-lab-advanced--user-data1404.yaml
+++ b/tcp_tests/templates/underlay/mk22-lab-advanced--user-data1404.yaml
@@ -90,7 +90,7 @@
    ########################################################
 
   write_files:
-   - path: /etc/network/interfaces.d/99-tcp-tests.cfg
+   - path: /etc/network/interfaces
      content: |
           auto eth0
           iface eth0 inet dhcp

--- a/tcp_tests/templates/underlay/mk22-lab-advanced--user-data1604.yaml
+++ b/tcp_tests/templates/underlay/mk22-lab-advanced--user-data1604.yaml
@@ -83,7 +83,7 @@
    ########################################################
 
   write_files:
-   - path: /etc/network/interfaces.d/99-tcp-tests.cfg
+   - path: /etc/network/interfaces
      content: |
           auto ens3
           iface ens3 inet dhcp

--- a/tcp_tests/templates/underlay/mk22-lab-basic--user-data-cfg01.yaml
+++ b/tcp_tests/templates/underlay/mk22-lab-basic--user-data-cfg01.yaml
@@ -48,7 +48,7 @@
    ########################################################
 
   write_files:
-   - path: /etc/network/interfaces.d/99-tcp-tests.cfg
+   - path: /etc/network/interfaces
      content: |
           auto ens3
           iface ens3 inet dhcp

--- a/tcp_tests/templates/underlay/mk22-lab-basic--user-data1404.yaml
+++ b/tcp_tests/templates/underlay/mk22-lab-basic--user-data1404.yaml
@@ -90,7 +90,7 @@
    ########################################################
 
   write_files:
-   - path: /etc/network/interfaces.d/99-tcp-tests.cfg
+   - path: /etc/network/interfaces
      content: |
           auto eth0
           iface eth0 inet dhcp

--- a/tcp_tests/templates/underlay/mk22-lab-basic--user-data1604.yaml
+++ b/tcp_tests/templates/underlay/mk22-lab-basic--user-data1604.yaml
@@ -86,7 +86,7 @@
    ########################################################
 
   write_files:
-   - path: /etc/network/interfaces.d/99-tcp-tests.cfg
+   - path: /etc/network/interfaces
      content: |
           auto ens3
           iface ens3 inet dhcp

--- a/tcp_tests/templates/underlay/mk22-qa-lab01--user-data-cfg01.yaml
+++ b/tcp_tests/templates/underlay/mk22-qa-lab01--user-data-cfg01.yaml
@@ -48,7 +48,7 @@
    ########################################################
 
   write_files:
-   - path: /etc/network/interfaces.d/99-tcp-tests.cfg
+   - path: /etc/network/interfaces
      content: |
           auto ens3
           iface ens3 inet dhcp

--- a/tcp_tests/templates/underlay/mk22-qa-lab01--user-data1404.yaml
+++ b/tcp_tests/templates/underlay/mk22-qa-lab01--user-data1404.yaml
@@ -90,7 +90,7 @@
    ########################################################
 
   write_files:
-   - path: /etc/network/interfaces.d/99-tcp-tests.cfg
+   - path: /etc/network/interfaces
      content: |
           auto eth0
           iface eth0 inet dhcp

--- a/tcp_tests/templates/underlay/mk22-qa-lab01--user-data1604.yaml
+++ b/tcp_tests/templates/underlay/mk22-qa-lab01--user-data1604.yaml
@@ -86,7 +86,7 @@
    ########################################################
 
   write_files:
-   - path: /etc/network/interfaces.d/99-tcp-tests.cfg
+   - path: /etc/network/interfaces
      content: |
           auto ens3
           iface ens3 inet dhcp

--- a/tcp_tests/templates/underlay/mk22-qa-lab01.yaml
+++ b/tcp_tests/templates/underlay/mk22-qa-lab01.yaml
@@ -153,7 +153,7 @@ template:
             role: salt_minion
             params:
               vcpu: !os_env SLAVE_NODE_CPU, 4
-              memory: !os_env SLAVE_NODE_MEMORY, 15000
+              memory: !os_env SLAVE_NODE_MEMORY, 12286
               boot:
                 - hd
               cloud_init_volume_name: iso
@@ -191,7 +191,7 @@ template:
             role: salt_minion
             params:
               vcpu: !os_env SLAVE_NODE_CPU, 4
-              memory: !os_env SLAVE_NODE_MEMORY, 15000
+              memory: !os_env SLAVE_NODE_MEMORY, 12286
               boot:
                 - hd
               cloud_init_volume_name: iso
@@ -217,7 +217,7 @@ template:
             role: salt_minion
             params:
               vcpu: !os_env SLAVE_NODE_CPU, 4
-              memory: !os_env SLAVE_NODE_MEMORY, 15000
+              memory: !os_env SLAVE_NODE_MEMORY, 12286
               boot:
                 - hd
               cloud_init_volume_name: iso


### PR DESCRIPTION
- fix dhclient issue with multiple instances for the same interface
- reduce 'max_heap_size' for cassandra in order to lower memory
  footprint