### PR TITLE
Add support for custom console log level

### DIFF
--- a/tcp_tests/logger.py
+++ b/tcp_tests/logger.py
@@ -28,7 +28,7 @@ logging.basicConfig(level=logging.DEBUG,
                     filemode='w')
 
 console = logging.StreamHandler()
-console.setLevel(logging.INFO)
+console.setLevel(settings.LOG_CON_LEVEL)
 formatter = logging.Formatter('%(asctime)s - %(levelname)s %(filename)s:'
                               '%(lineno)d -- %(message)s')
 console.setFormatter(formatter)

--- a/tcp_tests/settings.py
+++ b/tcp_tests/settings.py
@@ -11,9 +11,11 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+
+import logging
 import os
-import pkg_resources
 import time
+
 
 _boolean_states = {'1': True, 'yes': True, 'true': True, 'on': True,
                    '0': False, 'no': False, 'false': False, 'off': False}
@@ -25,6 +27,7 @@ def get_var_as_bool(name, default):
 
 
 LOGS_DIR = os.environ.get('LOGS_DIR', os.getcwd())
+LOG_CON_LEVEL = os.environ.get('LOG_CON_LEVEL', logging.INFO)
 TIMESTAT_PATH_YAML = os.environ.get(
     'TIMESTAT_PATH_YAML', os.path.join(
         LOGS_DIR, 'timestat_{}.yaml'.format(time.strftime("%Y%m%d"))))


### PR DESCRIPTION
Env variable named LOG_CON_LEVEL was added.
Its default value is "INFO" (same as before the change).